### PR TITLE
Install GE .inf file via NI Package and clarify installation steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Libraries
+*.lvlibp
+*.llb
+
 # Shared objects (inc. Windows DLLs)
 *.dll
 *.so
@@ -11,4 +15,6 @@
 # Metadata
 *.aliases
 *.lvlps
-*.lvlibp
+
+# Directories
+Built/

--- a/Components/Transceivers/GE Reflective Memory/GE Reflective Memory Windows.lvproj
+++ b/Components/Transceivers/GE Reflective Memory/GE Reflective Memory Windows.lvproj
@@ -15,6 +15,7 @@
 			<Item Name="Post-Build Action.vi" Type="VI" URL="../../Post-Build Action.vi"/>
 		</Item>
 		<Item Name="GE Reflective Memory.lvlib" Type="Library" URL="../Source/GE Reflective Memory.lvlib"/>
+		<Item Name="GE5565PIORC_NetworkInterrupts_DMA.inf" Type="Document" URL="../Driver/Source/GE5565PIORC_NetworkInterrupts_DMA.inf"/>
 		<Item Name="User Interface.vit" Type="VI" URL="../User Interface.vit"/>
 		<Item Name="Dependencies" Type="Dependencies">
 			<Item Name="vi.lib" Type="Folder">
@@ -336,7 +337,7 @@
 				<Property Name="Destination[1].path.type" Type="Str">relativeToProject</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
 				<Property Name="PackedLib_callersAdapt" Type="Bool">true</Property>
-				<Property Name="Source[0].itemID" Type="Str">{F1DAF1AA-CDD9-4F63-ADD3-2333CBD5C126}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{127F1CBA-3512-4509-9B94-5E5E9D620C2C}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/My Computer/GE Reflective Memory.lvlib</Property>
@@ -346,7 +347,10 @@
 				<Property Name="Source[1].preventRename" Type="Bool">true</Property>
 				<Property Name="Source[1].sourceInclusion" Type="Str">TopLevel</Property>
 				<Property Name="Source[1].type" Type="Str">Library</Property>
-				<Property Name="SourceCount" Type="Int">2</Property>
+				<Property Name="Source[2].destinationIndex" Type="Int">0</Property>
+				<Property Name="Source[2].itemID" Type="Ref">/My Computer/GE5565PIORC_NetworkInterrupts_DMA.inf</Property>
+				<Property Name="Source[2].sourceInclusion" Type="Str">Include</Property>
+				<Property Name="SourceCount" Type="Int">3</Property>
 				<Property Name="TgtF_companyName" Type="Str">NI</Property>
 				<Property Name="TgtF_fileDescription" Type="Str">GE Reflective Memory</Property>
 				<Property Name="TgtF_internalName" Type="Str">GE Reflective Memory</Property>

--- a/Docs/Getting Started with the GE Reflective Memory Component.md
+++ b/Docs/Getting Started with the GE Reflective Memory Component.md
@@ -5,13 +5,20 @@ Use this document to create a new data sharing framework custom device that leve
 
 ## Prerequisites
 Before starting this exercise, install the following software:
+
 - VeriStand
-- Data Sharing Framework ([DSF Releases](https://github.com/ni/niveristand-data-sharing-framework-custom-device-plugins/releases))
-   - *Note*: this package installs the GE Reflective Memory Plugin and the GE Reflective Memory Driver on the host computer and depends on the Data Sharing Framework Custom Device for VeriStand.
-   - **_Incompatibility_**: The GE Reflective Memory driver for this custom device is incompatible with the GE Fanuc driver installed by other software (including VeriStand). You must uninstall GE Fanuc driver from the RT target before continuing. 
-   - *Note*: To install the support for this custom device, copy the GE5565PIORC_NetworkInterrupts_DMA.inf to the RT target at :/ni-rt/system/ and reboot.
+- Data Sharing Framework ([DSF Releases](https://github.com/ni/niveristand-data-sharing-framework-custom-device/releases))
+- Data Sharing Framework Plugins ([DSF Plugins Releases](https://github.com/ni/niveristand-data-sharing-framework-custom-device-plugins/releases))
+- RT driver support for the GE Reflective Memory device
+   - **_Incompatibility_**: The GE Reflective Memory driver for this custom device is incompatible with the GE Fanuc driver installed through MAX, which is used by VeriStand's built-in reflective memory support. You must uninstall the GE Fanuc driver from the RT target before continuing.
+   - Locate the GE5565PIORC_NetworkInterrupts_DMA.inf file on disk. The .inf file is installed by the NI Package for this component and can be found on disk at the file path below:
+   ```
+   <Public Documents>\National Instruments\NI VeriStand 20xx\Custom Devices\Data Sharing Framework\Windows\Components
+   ```
+   - Right-click on the RT target in MAX and select **File Transfer**. Copy the .inf file to the RT target at c:/ni-rt/system/. Reboot the RT target to take effect.
+
    ![](support/GERMFileTransferToRTTarget.png)
-   
+
 ## Connect to the Remote System
 Identify and connect to the remote system using NI-MAX. Take note of the IP address of the remote system. For this loopback exercise, a single GE Reflective Memory device will both send and receive data.
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Includes the RT driver for the GE Reflective Memory device in the NI Package installer
- Updates the getting started guide to show how to install the .inf file to the RT target
- (Tech debt) Update .gitignore file to ignore Built directory

### Why should this Pull Request be merged?

Better support users to get started with the reflective memory component

### What testing has been done?

Validated output added the .inf file to the Built\Windows\Components directory.