### PR TITLE
Install to bitness specific locations

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -46,7 +46,7 @@ control_file = 'control_dsf_plugins'
 
 [package.payload_map]
 'Components\\Built\\Plugins' = 'documents\National Instruments\NI VeriStand {veristand_version}\Custom Devices\Data Sharing Framework'
-'Components\\Built\\Errors' = 'ni-paths-NISHAREDDIR\LabVIEW Run-Time\{veristand_version}\errors\English'
+'Components\\Built\\Errors' = 'ni-paths-NISHAREDDIR{nipaths_64_bitness_suffix}\LabVIEW Run-Time\{veristand_version}\errors\English'
 
 [notification]
 type = 'teams'

--- a/control_dsf_plugins
+++ b/control_dsf_plugins
@@ -12,4 +12,4 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI Data Sharing Framework Plugins for VeriStand {veristand_version}
-Depends: {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0), ni-data-sharing-framework-veristand-{veristand_version}-support (>= {display_version})
+Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-data-sharing-framework-veristand-{veristand_version}-support (>= {display_version})


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device-plugins/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update package installation paths and dependencies to accommodate different LabVIEW bitnesses.

### Why should this Pull Request be merged?

We are using LabVIEW 2021 64-bit.

### What testing has been done?

Inspected PR-built packages.

