### PR TITLE
Enable automated build for RDMA

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -15,6 +15,12 @@ path = 'Components\Transceivers\UDP\UDP Linux RT x64.lvproj'
 [projects.GEReflectiveMemory_windows]
 path = 'Components\Transceivers\GE Reflective Memory\GE Reflective Memory Windows.lvproj'
 
+[projects.RDMA_windows]
+path = 'Components\Transceivers\RDMA\RDMA Windows.lvproj'
+
+[projects.RDMA_linux_x64]
+path = 'Components\Transceivers\RDMA\RDMA Linux RT x64.lvproj'
+
 [[build.steps]]
 name = 'Data Sharing Framework UDP Plugin - Windows'
 type = 'lvBuildSpec'
@@ -38,6 +44,24 @@ project = '{GEReflectiveMemory_windows}'
 target = 'My Computer'
 build_spec = 'GE Reflective Memory'
 dependency_target = 'Windows'
+
+[[build.steps]]
+name = 'Data Sharing Framework RDMA Plugin - Windows'
+type = 'lvBuildSpec'
+project = '{RDMA_windows}'
+target = 'My Computer'
+build_spec = 'RDMA'
+dependency_target = 'Windows'
+minimum_version = '2020'
+
+[[build.steps]]
+name = 'Data Sharing Framework RDMA Plugin - Linux RT x64'
+type = 'lvBuildSpec'
+project = '{RDMA_linux_x64}'
+target = 'Linux RT x64'
+build_spec = 'RDMA'
+dependency_target = 'Linux_x64'
+minimum_version = '2020'
 
 [[package]]
 type = 'nipkg'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device-plugins/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enables automatic building of binaries and `nipkg` installer for the RMDA plugin added in #22.

### Why should this Pull Request be merged?

We want all of the plugins to be released at once using the automated build process.

### What testing has been done?

Dev branch build was successful. Unpacked the `nipkg` from the PR build and verified the RDMA PPL is correctly included.
