### PR TITLE
Depend on major version of DSF custom device

### DIFF
--- a/control_dsf_plugins
+++ b/control_dsf_plugins
@@ -12,4 +12,4 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI Data Sharing Framework Plugins for VeriStand {veristand_version}
-Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-data-sharing-framework-veristand-{veristand_version}-support (>= {display_version})
+Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-data-sharing-framework-veristand-{veristand_version}-support (>= {major_version})

--- a/control_dsf_plugins
+++ b/control_dsf_plugins
@@ -12,4 +12,4 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: NI Data Sharing Framework Plugins for VeriStand {veristand_version}
-Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-data-sharing-framework-veristand-{veristand_version}-support (>= {major_version})
+Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-data-sharing-framework-veristand-{veristand_version}-support (>= {major_version}.0.0)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device-plugins/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Installs the DSF plugins if the major version of DSF custom device (i.e. 21.0.0) is installed instead of depending on a strictly matching version.

### Why should this Pull Request be merged?

We're building a new version of the plugins to support RDMA, but do not want to release a new version of the DSF custom device because there are zero changes since the last release.

### What testing has been done?

Built PR against [build tools PR 130](https://github.com/ni/niveristand-custom-device-build-tools/pull/130) and verified `{major_version}` was correctly replaced and the package built.
