### PR TITLE
Build for 2023 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@
 
 def lvVersions = [
   32 : ['2020'],
-  64 : ['2021']
+  64 : ['2021', '2023']
 ]
 
 List<String> dependencies = ['niveristand-data-sharing-framework-custom-device']


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device-plugins/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enable a build supporting VeriStand 2023.

### Why should this Pull Request be merged?

We need a good build against in-dev 2023 to run automated testing.

### What testing has been done?

Successful branch build.
