### PR TITLE
shorten payloads

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,6 +67,6 @@ stages:
         - controlFileName: 'control_dsf_plugins'
           payloadMaps:
             - installLocation: 'documents\National Instruments\NI VeriStand $(lvVersion)\Custom Devices\Data Sharing Framework'
-              payloadLocation: 'Components\Built\Plugins'
+              payloadLocation: 'Plugins'
             - installLocation: 'ni-paths-NISHAREDDIR$(nipkgx64suffix)\LabVIEW Run-Time\$(lvVersion)\errors\English'
-              payloadLocation: 'Components\Built\Errors'
+              payloadLocation: 'Errors'


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device-plugins/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Now that we are using payloads from nirvana archives, we do not need to include the build output path.

### Why should this Pull Request be merged?

If this is not included, we will not have any payloads in the builds

### What testing has been done?

PR Build output
