### PR TITLE
Bump release version to 23.8

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ stages:
           target: 'Linux x64'
           buildSpec: 'RDMA'
 
-      releaseVersion: '23.5.0'
+      releaseVersion: '23.8.0'
       buildOutputLocation: 'Components\Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\data_sharing_framework_plugins'
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device-plugins/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Bump release version to 23.8

### Why should this Pull Request be merged?

We will release the custom device and plugins for 2023 Q4, so the version of plugins needs to be 23.8 to match

### What testing has been done?

None
