### PR TITLE
Build for VeriStand 2024, drop 2020

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,11 +24,11 @@ stages:
   - template: azure-templates/stages.yml@niveristand-custom-device-build-tools
     parameters:
       lvVersionsToBuild:
-        - version: '2020'
-          bitness: '32bit'
         - version: '2021'
           bitness: '64bit'
         - version: '2023'
+          bitness: '64bit'
+        - version: '2024'
           bitness: '64bit'
 
       dependencies:
@@ -62,7 +62,7 @@ stages:
           target: 'Linux x64'
           buildSpec: 'RDMA'
 
-      releaseVersion: '23.8.0'
+      releaseVersion: '24.0.0'
       buildOutputLocation: 'Components\Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\data_sharing_framework_plugins'
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device-plugins/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Build the DSF plugins for VeriStand/LabVIEW 2024, drop 2020 support.

### Why should this Pull Request be merged?

Needed for a future release.

### What testing has been done?

PR build.
